### PR TITLE
Refactor project to include multiple blink examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# General
+*.o
+*.obj
+*.elf
+*.bin
+*.hex
+*.map
+*.bak
+*.tmp
+*.swo
+*.swp
+*~
+
+# Build directories
+Debug/
+Release/
+build/
+**/build/
+**/Debug/
+**/Release/
+
+# STM32CubeIDE
+.project
+.cproject
+.settings/
+*.launch
+*.ioc
+
+# PlatformIO
+.pio/
+.vscode/ # Can be user-specific, but often added for PIO projects
+
+# Keil
+*.uvproj
+*.uvopt
+*.uvgui
+*.uvprojx
+*.uvoptx
+*.uvguix
+Listings/
+Objects/
+RTE/
+
+# Other IDEs / System files
+.DS_Store
+Thumbs.db
+Desktop.ini

--- a/BareMetal/README.md
+++ b/BareMetal/README.md
@@ -1,0 +1,39 @@
+# Bare-Metal LED Blink Example
+
+This directory contains a bare-metal LED blinking example for the STM32 Blue Pill board (STM32F103C8T6). The code directly manipulates hardware registers to control the GPIO and clock settings.
+
+The onboard LED, typically connected to pin PC13, will blink continuously.
+
+## Code (`main.c`)
+
+The `main.c` file performs the following actions:
+1.  Includes the necessary header `stm32f1xx.h`.
+2.  Implements a basic software delay function.
+3.  Enables the clock for the GPIOC peripheral using direct register access.
+4.  Configures pin PC13 as a general-purpose push-pull output using direct register access.
+5.  Enters an infinite loop that toggles PC13 (turns the LED on and off) with a delay.
+
+## How to Use
+
+Refer to the main project README for general guidance on:
+*   Toolchain Setup (e.g., GNU Arm Embedded Toolchain)
+*   Compilation (using `arm-none-eabi-gcc`, requires a linker script)
+*   Flashing (using OpenOCD, STM32CubeProgrammer, etc.)
+
+**Example Compilation Steps (from root README):**
+(Ensure you have an ARM GCC toolchain and a linker script for STM32F103C8T6)
+
+```bash
+# Navigate to this directory if you want to compile here, or adjust paths
+# cd BareMetal
+
+# Compile main.c into an object file
+arm-none-eabi-gcc -c -mcpu=cortex-m3 -mthumb -std=c99 -O1 -Wall -fdata-sections -ffunction-sections -g main.c -o main.o
+
+# Link the object file to create an ELF executable (ensure linker script is accessible)
+arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -T<path_to_your_linker_script.ld> main.o -o blink.elf -Wl,-Map=blink.map,--gc-sections
+
+# Convert ELF to a binary file (for flashing)
+arm-none-eabi-objcopy -O binary blink.elf blink.bin
+```
+This example is fundamental and demonstrates direct hardware control without HAL or other abstraction layers.

--- a/BareMetal/main.c
+++ b/BareMetal/main.c
@@ -1,0 +1,45 @@
+// Include necessary headers
+#include "stm32f1xx.h"
+
+// Simple software delay function
+void delay(uint32_t count) {
+    for (volatile uint32_t i = 0; i < count; i++) {
+        // This loop creates a delay
+        // 'volatile' is used to prevent the compiler from optimizing away the loop
+    }
+}
+
+int main(void) {
+    // Enable Clock for GPIOC
+    // The LED on Blue Pill boards is typically connected to PC13.
+    // The clock for Port C needs to be enabled first via the RCC peripheral.
+    RCC->APB2ENR |= RCC_APB2ENR_IOPCEN;
+
+    // Configure PC13 as Output
+    // Clear any existing configuration for PC13 (bits 20-23 for PC13 in CRH)
+    GPIOC->CRH &= ~(GPIO_CRH_CNF13 | GPIO_CRH_MODE13);
+    // Set PC13 as general-purpose output push-pull, max speed 10MHz
+    // MODE13[1:0] = 01 (Output mode, max speed 10 MHz)
+    // CNF13[1:0] = 00 (General purpose output push-pull)
+    GPIOC->CRH |= (GPIO_CRH_MODE13_0); // MODE13[0] = 1, MODE13[1] = 0 (10MHz)
+                                     // CNF13 is already 00 by previous clearing
+
+    // Infinite loop to blink the LED
+    while (1) {
+        // Turn the LED ON (Set PC13 low)
+        // The LED on Blue Pill is typically connected such that a LOW signal turns it ON.
+        GPIOC->BRR = (1 << 13); // Set PC13 low using Bit Reset Register
+
+        // Call the delay function
+        delay(1000000); // Adjust this value to change the blinking speed
+
+        // Turn the LED OFF (Set PC13 high)
+        GPIOC->BSRR = (1 << 13); // Set PC13 high using Bit Set Register
+
+        // Call the delay function again
+        delay(1000000); // Adjust this value to change the blinking speed
+    }
+
+    // This part will never be reached
+    return 0;
+}

--- a/PlatformIO_Arduino/README.md
+++ b/PlatformIO_Arduino/README.md
@@ -1,0 +1,43 @@
+# PlatformIO Arduino LED Blink Example
+
+This directory contains an LED blinking example for the STM32 Blue Pill board (STM32F103C8T6) using the PlatformIO IDE and the Arduino framework (STM32duino).
+
+The onboard LED, typically connected to pin PC13, will blink continuously.
+
+## Project Files
+
+*   `platformio.ini`: The PlatformIO project configuration file. It specifies the board, platform (ST STM32), and framework (Arduino).
+*   `src/main.cpp`: The main Arduino sketch that controls the LED.
+
+## Prerequisites
+
+*   **Visual Studio Code** with the **PlatformIO IDE extension** installed.
+    *   You can install it from the VS Code Extensions view (search for `platformio.platformio-ide`).
+*   **ST-Link V2 programmer** (or other compatible programmer configured in `platformio.ini`).
+
+## How to Use
+
+1.  **Open with PlatformIO:**
+    *   Open Visual Studio Code.
+    *   Click on the PlatformIO icon on the left sidebar (or `Ctrl+Alt+P` / `Cmd+Alt+P` and search for PlatformIO).
+    *   Choose "Open Project" and select the `PlatformIO_Arduino` folder.
+
+2.  **Build:**
+    *   Click the "Build" button (checkmark icon) on the PlatformIO toolbar at the bottom of VS Code.
+    *   Or, open a PlatformIO CLI terminal (terminal icon on the PlatformIO toolbar) and run:
+        ```bash
+        pio run
+        ```
+
+3.  **Upload:**
+    *   Connect your ST-Link programmer to the Blue Pill and your computer.
+    *   Click the "Upload" button (right arrow icon) on the PlatformIO toolbar.
+    *   Or, in the PlatformIO CLI terminal, run:
+        ```bash
+        pio run --target upload
+        ```
+
+The LED on PC13 should now be blinking!
+
+### Note on LED_BUILTIN / PC13:
+The code uses `PC13` as the LED pin, which is common for Blue Pill boards. The Arduino framework for STM32 sometimes defines `LED_BUILTIN`. This code explicitly uses `PC13` if `LED_BUILTIN` isn't already defined, ensuring it targets the correct pin. The LED on many Blue Pill boards is active LOW, meaning `digitalWrite(PC13, LOW)` turns it ON and `digitalWrite(PC13, HIGH)` turns it OFF. The provided `main.cpp` uses HIGH for ON and LOW for OFF; you might need to swap these if your specific board's LED behaves inversely. For consistency with typical Arduino sketches, this example uses HIGH for ON.

--- a/PlatformIO_Arduino/platformio.ini
+++ b/PlatformIO_Arduino/platformio.ini
@@ -1,0 +1,7 @@
+[env:bluepill_f103c8]
+platform = ststm32
+board = bluepill_f103c8
+framework = arduino
+upload_protocol = stlink
+; You can also add monitor_speed if you plan to use Serial output
+; monitor_speed = 115200

--- a/PlatformIO_Arduino/src/main.cpp
+++ b/PlatformIO_Arduino/src/main.cpp
@@ -1,0 +1,18 @@
+#include <Arduino.h>
+
+// Define the LED pin. On Blue Pill, the onboard LED is usually PC13.
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN PC13
+#endif
+
+void setup() {
+  // Initialize the digital pin as an output.
+  pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+  digitalWrite(LED_BUILTIN, HIGH); // Turn the LED on (HIGH is the voltage level)
+  delay(500);                      // Wait for 500ms
+  digitalWrite(LED_BUILTIN, LOW);  // Turn the LED off by making the voltage LOW
+  delay(500);                      // Wait for 500ms
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-# HIBUTTA
-Learn coding 
+# STM32 Blue Pill LED Blink Examples
+
+This repository provides simple LED blinking examples for the STM32 Blue Pill board (STM32F103C8T6), demonstrating different approaches to firmware development. The onboard LED, typically connected to pin PC13, will blink continuously with each example.
+
+## Examples Included
+
+This project includes the following examples, each in its own directory:
+
+1.  **[BareMetal/](BareMetal/)**:
+    *   A fundamental LED blink example using direct C register manipulation (RCC, GPIO).
+    *   No external libraries (beyond standard C and CMSIS headers typically bundled with toolchains).
+    *   Good for understanding low-level hardware interaction.
+    *   Requires manual setup of an ARM GCC toolchain and linker script.
+
+2.  **[PlatformIO_Arduino/](PlatformIO_Arduino/)**:
+    *   An LED blink example using the PlatformIO IDE with the Arduino framework (STM32duino).
+    *   Simplifies development with familiar Arduino functions (`pinMode`, `digitalWrite`, `delay`).
+    *   Manages toolchain and library dependencies automatically.
+    *   Recommended for quick prototyping and those familiar with the Arduino ecosystem.
+
+## Hardware Required
+
+*   STM32 Blue Pill board (STM32F103C8T6)
+*   ST-Link V2 programmer (or other compatible SWD programmer, especially for the BareMetal example. PlatformIO can also use other upload methods if configured).
+*   USB cable
+
+## How to Use
+
+1.  **Clone the Repository:**
+    ```bash
+    git clone <repository_url>
+    cd <repository_directory_name>
+    ```
+    (Replace `<repository_url>` and `<repository_directory_name>` with the actual URL and local directory name)
+
+2.  **Navigate to an Example:**
+    Choose one of the example directories:
+    *   `cd BareMetal`
+    *   `cd PlatformIO_Arduino`
+
+3.  **Follow Example-Specific Instructions:**
+    Each example directory (`BareMetal/`, `PlatformIO_Arduino/`) contains its own `README.md` file with detailed instructions for building, flashing, and running that specific example. Please refer to those READMEs for guidance.
+
+## Board Details
+
+For more information on the STM32 Blue Pill board (STM32F103C8T6), check out this excellent resource:
+- [STM32F103C8T6 Blue Pill Details](https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill.html)
+
+## Getting Started with STM32duino (Arduino on STM32)
+
+If you're interested in using the Arduino framework with your STM32 Blue Pill, particularly for the PlatformIO example or general STM32duino development, this guide is a great starting point:
+- [Introduction to STM32 Blue Pill with STM32duino](https://predictabledesigns.com/introduction-stm32-blue-pill-stm32duino/)
+
+## Acknowledgements
+
+Thanks to Jules (the AI assistant) and ChatGPT for their help in creating and refining this project.
+
+## Disclaimer
+
+These are basic examples intended for demonstration. For more complex projects, consider leveraging more features of your chosen toolchain/framework (like STM32CubeMX for HAL code generation if not using Arduino, or advanced PlatformIO library management).


### PR DESCRIPTION
This commit significantly restructures the project to provide multiple LED blink examples for the STM32 Blue Pill board:

1.  **BareMetal Example:**
    - The original direct register access `main.c` is moved to `BareMetal/`.
    - Includes a dedicated `README.md` for bare-metal compilation.

2.  **PlatformIO Arduino Example:**
    - Adds a new example in `PlatformIO_Arduino/` using the Arduino framework via PlatformIO.
    - Includes `platformio.ini`, `src/main.cpp`, and a dedicated `README.md` for easy building and uploading with PlatformIO.

3.  **Root README Update:**
    - The main `README.md` is updated to serve as a top-level guide, directing you to the different examples.
    - Incorporates links for board details (stm32-base.org) and getting started with STM32duino (predictabledesigns.com).
    - Adds an acknowledgements section.

4.  **`.gitignore`:**
    - A comprehensive `.gitignore` file is added to the project root to exclude build artifacts and IDE-specific files.

This enhances the repository by offering you different approaches to STM32 development, from low-level bare-metal to higher-level Arduino framework integration.